### PR TITLE
Limit the upper version of typeguard

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy
 pandas>=0.23
 pandas-stubs
-typeguard
+typeguard<=2.13.3


### PR DESCRIPTION
Typeguard released 3.0.0 today https://typeguard.readthedocs.io/en/latest/versionhistory.html This is a breaking change.