### PR TITLE
Restrict typeguard version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy
 pandas>=0.23
 pandas-stubs
-typeguard
+typeguard==2.13.3


### PR DESCRIPTION
Do not use latest typeguard which is backwards-incompatible