### PR TITLE
Remove no cloning part from the documentation

### DIFF
--- a/docs/source/advanced.ipynb
+++ b/docs/source/advanced.ipynb
@@ -222,64 +222,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## No cloning\n",
-    "\n",
-    "When a `DataFrame` is cast to a `DataSet`, the underlying data isn't cloned (unless you use `DataSet[Schema](..., copy=True)`). This is great for memory purposes, but it does require some caution. For example, consider the following pandas script:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df1 = pd.DataFrame({\"id\": [1, 2, 3], \"name\": [\"John\", \"Jane\", \"Jack\"]})\n",
-    "df2 = pd.DataFrame(df1)\n",
-    "df1.name = [1, 2, 3]\n",
-    "df2.name"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Here, `df1` and `df2` essentially point to the same data, so changing one of them changes the other one too. This behaviour extends to `DataSet` as well."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "class Schema:\n",
-    "    id: int\n",
-    "    name: str\n",
-    "\n",
-    "df1 = pd.DataFrame({\"id\": [1, 2, 3], \"name\": [\"John\", \"Jane\", \"Jack\"]})\n",
-    "df2 = DataSet[Schema](df1)\n",
-    "\n",
-    "df1.name = [1, 2, 3]\n",
-    "df2.name"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "This is somewhat problematic, because we now made a change to the schema, without any error thrown whatsoever! However:\n",
-    "\n",
-    "* I essentially can't stop you from doing this (apart from forcing `DataSet` to copy the data when created, which I won't).\n",
-    "\n",
-    "* If this happens in your code, you have bigger problems that type checking.\n",
-    "\n",
-    "So the bottomline is: be careful when dealing with pointers!"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},


### PR DESCRIPTION
The problem described there used to be a problem, but has been resolved in pandas since. See #84.