### PR TITLE
Clean up files so that pre-commit hooks are clean.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,6 +14,8 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
+# This is a configuration file we shouldn't be checking it.
+# mypy: ignore-errors
 
 # -- Project information -----------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,0 @@
-[tool.mypy]
-exclude = ['^docs\/.+\.py$']

--- a/tests/test_type_validation.py
+++ b/tests/test_type_validation.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import numpy as np  # type: ignore
 
-from typing import Any, Callable
+from typing import Any, Callable, Union
 
 from strictly_typed_pandas import DataSet, IndexedDataSet
 from strictly_typed_pandas.pandas_types import (
@@ -28,7 +28,7 @@ def is_backward_compatibility_type(dtype) -> bool:
     return False
 
 
-def are_they_equal(observed, expected):
+def are_they_equal(observed, expected) -> Union[bool, float]:
     if is_backward_compatibility_type(observed) or is_backward_compatibility_type(expected):
         return np.nan
 
@@ -125,6 +125,6 @@ def test_supported_index_data_type():
             continue
 
         class IndexSchema:
-            a: dtype
+            a: dtype  # type: ignore
 
         IndexedDataSet[IndexSchema, DataSchema]()


### PR DESCRIPTION
No more errors or warnings when running `pre-commit run --all-files`.

