### PR TITLE
Fix warnings raised in tests

### DIFF
--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -27,8 +27,8 @@ def test_empty_dataset() -> None:
     assert df.shape[0] == 0
     assert np.all(df.columns == ["a", "b"])
 
-    assert df.dtypes[0] == int
-    assert df.dtypes[1] == object or isinstance(df.dtypes[1], StringDtype)
+    assert df.dtypes.iloc[0] == int
+    assert df.dtypes.iloc[1] == object or isinstance(df.dtypes.iloc[1], StringDtype)
 
 
 def test_dataset() -> None:

--- a/tests/test_indexed_dataset.py
+++ b/tests/test_indexed_dataset.py
@@ -34,8 +34,8 @@ def test_empty_indexed_dataset() -> None:
     assert df.index.get_level_values(0).dtype == int
     assert df.index.get_level_values(1).dtype == object or isinstance(df.index.get_level_values(1).dtype, StringDtype)
 
-    assert df.dtypes[0] == int
-    assert df.dtypes[1] == object or isinstance(df.dtypes[1], StringDtype)
+    assert df.dtypes.iloc[0] == int
+    assert df.dtypes.iloc[1] == object or isinstance(df.dtypes.iloc[1], StringDtype)
 
 
 def test_indexed_dataset() -> None:

--- a/tests/test_type_validation.py
+++ b/tests/test_type_validation.py
@@ -21,7 +21,7 @@ def is_backward_compatibility_type(dtype) -> bool:
     if isinstance(dtype, BackwardCompatibility):
         return True
 
-    if dtype not in [Any, np.integer]:
+    if dtype != Any:
         if isinstance(dtype, Callable) and isinstance(dtype(), BackwardCompatibility):  # type: ignore
             return True
 
@@ -58,13 +58,13 @@ def check_list_of_types(observed, expected_to_match, expected_to_fail):
 
 
 def test_numeric_base_python_types():
-    check_list_of_types(int, [np.int64, np.int_, np.integer, int], [float, np.float_])
+    check_list_of_types(int, [np.int64, np.int_, int], [float, np.float_])
     check_list_of_types(float, [np.float64, np.float_, float], [int, np.int_])
     check_list_of_types(bool, [np.bool_, bool], [int, np.int_])
 
 
 def test_numpy_types():
-    check_list_of_types(np.int64, [np.int64, np.int_, np.integer, int], [float, np.float_])
+    check_list_of_types(np.int64, [np.int64, np.int_, int], [float, np.float_])
     check_list_of_types(np.float64, [np.float64, np.float_, float], [int, np.int_])
     check_list_of_types(np.bool_, [np.bool_, bool], [int, np.int_])
     check_list_of_types(np.datetime64, [np.datetime64], [np.timedelta64, DatetimeTZDtype(tz="UTC"), np.int_])
@@ -99,7 +99,7 @@ def test_strings():
 
     # as long as this is true
     df = pd.DataFrame({"a": ["a", "b", "c"]})
-    assert df.dtypes[0] == object
+    assert df.dtypes.iloc[0] == object
     # we'll need to do this
     check_list_of_types(object, [str], [StringDtype])
 


### PR DESCRIPTION
Running `pytest tests/* --typeguard-packages=strictly_typed_pandas,tests` yielded a few warnings I fixed up.  

The only warning left is

```
tests/test_type_validation.py::test_numpy_types
  /usr/local/google/home/caneff/git/strictly_typed_pandas/strictly_typed_pandas/validate_schema.py:54: DeprecationWarning: Converting `np.integer` or `np.signedinteger` to a dtype is deprecated. The current result is `np.dtype(np.int_)` which is not strictly correct. Note that the result depends on the system. To ensure stable results use may want to use `np.int64` or `np.int32`.
    if dtype_observed == dtype_expected or np.issubdtype(dtype_observed, dtype_expected):
```

Couldn't figure out how to work around that one though. Hoping you had some thoughts @nanne-aben 