### PR TITLE
Add clearer error message for a missing index.

### DIFF
--- a/strictly_typed_pandas/dataset.py
+++ b/strictly_typed_pandas/dataset.py
@@ -170,5 +170,8 @@ class IndexedDataSet(Generic[T, V], DataSetBase):
                 for i, name in enumerate(self.index.names)
             }
 
+            if all(name is None for name in self.index.names):
+                raise TypeError("No named columns in index. Did you remember to set the index?")
+
             validate_schema(schema_index_expected, schema_index_observed)
             validate_schema(schema_data_expected, schema_data_observed)

--- a/tests/test_indexed_dataset.py
+++ b/tests/test_indexed_dataset.py
@@ -48,6 +48,11 @@ def test_indexed_dataset() -> None:
     )
 
 
+def test_missing_index():
+    with pytest.raises(TypeError, match="No named columns in index"):
+        pd.DataFrame({"a": [1, 2, 3]}).pipe(IndexedDataSet[IndexSchema, DataSchema])
+
+
 def test_overlapping_columns():
     with pytest.raises(TypeError):
         IndexedDataSet[IndexSchema, IndexSchema]()


### PR DESCRIPTION
There are many ways I could check this but this seems the easiest.  There will always be a range index at least so this should always make sense.

Fixes #110 